### PR TITLE
feat/migrate mise to new version

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -9,7 +9,7 @@ rust = 'nightly'
 [alias.node.versions]
 '20.x' = '20'
 
-[plugins]
+[alias]
 deno = 'https://github.com/asdf-community/asdf-deno'
 go = 'https://github.com/asdf-community/asdf-golang'
 python = 'https://github.com/asdf-community/asdf-python'

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -6,7 +6,7 @@ node = ['lts', '22']
 python = '3.12'
 rust = 'nightly'
 
-[alias.node]
+[alias.node.versions]
 '20.x' = '20'
 
 [plugins]


### PR DESCRIPTION
- **feat(mise): use `alias.node.versions` instead of `alias.node`**
- **feat: use `alias` instead of `plugins`**
